### PR TITLE
Add Feature: Delete Event Date

### DIFF
--- a/.github/workflows/Mac.yml
+++ b/.github/workflows/Mac.yml
@@ -112,6 +112,20 @@ jobs:
           ls -aril          
           cat dummy.pgn
 
+      - name: Remove Event Date in PGN
+        working-directory: test
+        run: |
+          pgn -EventDate parse.pgn
+          ls -aril          
+          cat parse.pgn
+
+      - name: Remove Event Date in JSON
+        working-directory: test
+        run: |
+          pgn -EventDate test.json
+          ls -aril          
+          cat test.json 
+
       - name: Clean
         run: |
           git clean -fX

--- a/.github/workflows/Mac.yml
+++ b/.github/workflows/Mac.yml
@@ -2,11 +2,7 @@ name: MacOS
 
 on:
   push:
-    branches:
-      - *
   pull_request:
-    branches:
-      - *
 
 jobs:
   test:

--- a/.github/workflows/Mac.yml
+++ b/.github/workflows/Mac.yml
@@ -3,10 +3,10 @@ name: MacOS
 on:
   push:
     branches:
-      - main
+      - *
   pull_request:
     branches:
-      - main
+      - *
 
 jobs:
   test:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,6 +112,19 @@ jobs:
           pgn -parseJSON games.json dummy.pgn
           ls -aril
           cat dummy.pgn
+      - name: Remove Event Date in PGN
+        working-directory: test
+        run: |
+          pgn -EventDate parse.pgn
+          ls -aril          
+          cat parse.pgn
+
+      - name: Remove Event Date in JSON
+        working-directory: test
+        run: |
+          pgn -EventDate test.json
+          ls -aril          
+          cat test.json 
 
       - name: Clean
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,11 +2,7 @@ name: Linux
 
 on:
   push:
-    branches:
-      - *
   pull_request:
-    branches:
-      - *
 
 jobs:
   test:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,10 +3,10 @@ name: Linux
 on:
   push:
     branches:
-      - main
+      - *
   pull_request:
     branches:
-      - main
+      - *
 
 jobs:
   test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,10 +3,10 @@ name: Windows
 on:
   push:
     branches:
-      - main
+      - *
   pull_request:
     branches:
-      - main
+      - *
 
 jobs:
   test:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -113,7 +113,7 @@ jobs:
         working-directory: test
         run: |
           .\pgn.exe -EventDate parse.pgn
-          ls -aril          
+          ls    
           type parse.pgn
 
       - name: Remove Event Date in JSON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -109,6 +109,19 @@ jobs:
           .\pgn.exe -parseJSON games.json dummy.pgn
           ls
           type dummy.pgn
+      - name: Remove Event Date in PGN
+        working-directory: test
+        run: |
+          pgn -EventDate parse.pgn
+          ls -aril          
+          type parse.pgn
+
+      - name: Remove Event Date in JSON
+        working-directory: test
+        run: |
+          pgn -EventDate test.json
+          ls           
+          type test.json 
 
       - name: Clean
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -112,14 +112,14 @@ jobs:
       - name: Remove Event Date in PGN
         working-directory: test
         run: |
-          pgn -EventDate parse.pgn
+          .\pgn.exe -EventDate parse.pgn
           ls -aril          
           type parse.pgn
 
       - name: Remove Event Date in JSON
         working-directory: test
         run: |
-          pgn -EventDate test.json
+          .\pgn.exe -EventDate test.json
           ls           
           type test.json 
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,11 +2,7 @@ name: Windows
 
 on:
   push:
-    branches:
-      - *
   pull_request:
-    branches:
-      - *
 
 jobs:
   test:

--- a/Readme.md
+++ b/Readme.md
@@ -49,15 +49,12 @@ If no output pgn is specified, the name of the json is adopted.
 
 
 ### Delete Event Date
-> [!CAUTION]  
-> The flag is not yet working. Errors occur when reading the input file. This function is not available in the current release.
+> [!Note]  
+> This function is not available in the current release. To be able to use this function, you must build the project yourself.
 
 The function removes the Event Date attribute from the PGN files. The attribute generates errors in ChessBase and ChessX for files that are connected to DGT boards and the Lichess API.
 ```bash
 pgn -EventDate test.pgn
-```
-or
-```bash
 pgn -EventDate test.json
 ```
 The flag accepts both pgn and json files. 

--- a/Readme.md
+++ b/Readme.md
@@ -57,4 +57,4 @@ The function removes the Event Date attribute from the PGN files. The attribute 
 pgn -EventDate test.pgn
 pgn -EventDate test.json
 ```
-The flag accepts both pgn and json files. 
+The flag accepts both pgn and json files.  The basic problem is that the EventDate attribute overwrites the other Date attribute. As a result, the wrong date is displayed in PGN files.

--- a/functioneventdate.go
+++ b/functioneventdate.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/fatih/color"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -70,7 +69,7 @@ func eventdate() {
 	}
 
 	// Inhalt der JSON-Datei lesen
-	var inputBytes, err = ioutil.ReadFile(uuidfile + ".json")
+	inputBytes, err := os.ReadFile(uuidfile + ".json")
 	if err != nil {
 		color.Red("Fehler beim Lesen der JSON-Datei:", err)
 		os.Exit(1)
@@ -96,7 +95,7 @@ func eventdate() {
 	}
 
 	// Inhalt in die Ausgabedatei schreiben
-	if err := ioutil.WriteFile(inputfile, outputBytes, 0644); err != nil {
+	if err := os.WriteFile(inputfile, outputBytes, 0644); err != nil {
 		color.Red("Fehler beim Schreiben der JSON-Datei:", err)
 		os.Exit(1)
 	}
@@ -106,11 +105,12 @@ func eventdate() {
 	// Wenn die ursprungsdatei eine PGN Datei war, lösche die ursprüngliche Datei
 	// und wandel es wieder als PGN um
 	if filetype == "pgn" {
-		err := os.Remove(inputfile)
-		if err != nil {
-			color.Red("Can't delete file:", err)
-			return
-		}
+		/*
+			err := os.Remove(inputfile)
+			if err != nil {
+				color.Red("Can't delete file:", err)
+				return
+			} */
 		if err := parseJSONFile(uuidfile+".json", inputfile); err != nil {
 			panic(err)
 		}

--- a/functioneventdate.go
+++ b/functioneventdate.go
@@ -40,7 +40,6 @@ func eventdate() {
 	if strings.HasSuffix(strings.ToLower(inputfile), ".json") {
 		filetype = "json"
 	}
-	fmt.Println(filetype)
 
 	// Prüfe ob die Datei existiert
 	if _, err := os.Stat(inputfile); os.IsNotExist(err) {
@@ -48,8 +47,23 @@ func eventdate() {
 		os.Exit(1)
 	}
 
+	color.Yellow("input:" + inputfile)
+	color.Yellow("filetype:" + filetype)
+	color.Yellow("UUIDFile:" + uuidfile)
+
 	// Wandelt die PGN temporär in eine JSON um
-	if filetype == "json" {
+	if filetype == "pgn" {
+		file, err := os.Create(uuidfile + ".json")
+		if err != nil {
+			fmt.Println("Fehler beim Erstellen der Datei:", err)
+			return
+		}
+		defer func(file *os.File) {
+			err := file.Close()
+			if err != nil {
+
+			}
+		}(file)
 		if err := parsePGNFile(inputfile, uuidfile+".json"); err != nil {
 			panic(err)
 		}

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-git checkout main
+git checkout work
 git pull
 go mod tidy
 go test -v

--- a/test/games.json
+++ b/test/games.json
@@ -9,7 +9,8 @@
             "Result": "1-0",
             "Round": "6",
             "Site": "New York, NY USA",
-            "White": "Deep Blue"
+            "White": "Deep Blue",
+            "EventDate": "2024.??.??"
         },
         "moves": "1.e4 c6 2.d4 d5 3.Nc3 dxe4 4.Nxe4 Nd7 5.Ng5 Ngf6 6.Bd3 e6 7.N1f3 h6 8.Nxe6 Qe7 9.O-O fxe6 10.Bg6+ Kd8 {Kasparov schüttelt kurz den Kopf} 11.Bf4 b5 12.a4 Bb7 13.Re1 Nd5 14.Bg3 Kc8 15.axb5 cxb5 16.Qd3 Bc6 17.Bf5 exf5 18.Rxe7 Bxe7 19.c4 1-0  "
     },
@@ -24,7 +25,8 @@
             "Termination": "ACEChess won by resignation",
             "TimeControl": "1 in 3 days",
             "White": "ACEChess",
-            "WhiteElo": "2037"
+            "WhiteElo": "2037",
+            "EventDate": "2024.??.??"
         },
         "moves": "1.e4 d5 2.exd5 Nf6 3.d4 Nxd5 4.c4 Nb6 5.Nc3 g6 6.Be3 Bg7 7.h3 O-O 8.Qd2 Nc6 9.Nf3 e5 10.d5 Ne7 11.g4 f5 12.O-O-O e4 13.Ng5 h6 14.Ne6 Bxe6 15.dxe6 Qxd2+ 16.Rxd2 Rad8 17.Bc5 Rxd2 18. Kxd2 Rd8+ 19.Kc2 Nc6 20.gxf5 Nd4+ 21.Bxd4 Rxd4 22.Rg1 g5 23.c5 Nc4 24.Bxc4 Rxc4 25.Rd1 Bf6 26.Kb3 Rxc5 27.Nxe4 Rxf5 28.Nxf6+ Kf8 29.Ng4 h5 30.Ne3 Rf3 31.Rd5 g4 32.hxg4 1-0  "
     },


### PR DESCRIPTION
### Delete Event Date
> [!Note]  
> This function is not available in the current release. To be able to use this function, you must build the project yourself.

The function removes the Event Date attribute from the PGN files. The attribute generates errors in ChessBase and ChessX for files that are connected to DGT boards and the Lichess API.
```bash
pgn -EventDate test.pgn
pgn -EventDate test.json
```
The flag accepts both pgn and json files.  The basic problem is that the EventDate attribute overwrites the other Date attribute. As a result, the wrong date is displayed in PGN files.
