### PR TITLE
Remove unused warning

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,3 @@
-> [!WARNING]  
-> The project is still in progress. There is no realease and no stable version yet. The current use is at your own risk.
-
 # PGN Helper
 
 [![Windows](https://github.com/eskopp/PGNHelper/actions/workflows/windows.yml/badge.svg)](https://github.com/eskopp/PGNHelper/actions/workflows/windows.yml) [![Linux](https://github.com/eskopp/PGNHelper/actions/workflows/linux.yml/badge.svg)](https://github.com/eskopp/PGNHelper/actions/workflows/linux.yml) [![Mac](https://github.com/eskopp/PGNHelper/actions/workflows/Mac.yml/badge.svg)](https://github.com/eskopp/PGNHelper/actions/workflows/Mac.yml)


### PR DESCRIPTION
Remove: 

> [!WARNING]  
> The project is still in progress. There is no realease and no stable version yet. The current use is at your own risk.
