### PR TITLE
Remove CB Files to Readme (#20 and #21)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,3 +69,16 @@ pgn -deletepgn test.pgn
 pgn -createjson test.json
 pgn -deletejson test.json
 ```
+
+
+### Remove Chessbase Files
+> [!NOTE]  
+> The function is not yet included in the current release.
+
+> [!TIP]  
+> Chessbase does not need these files, if you open the PGN file again Chessbase will create the files again. You can only delete the files if you have closed Chessbase.
+
+The flag deletes all pgi and ini files of Chessbase from the folder. This leaves the PGN files. Chessbase archives and CBH archives remain unaffected.
+```bash
+pgn -removecb
+```


### PR DESCRIPTION
### Remove Chessbase Files
> [!NOTE]  
> The function is not yet included in the current release.

> [!TIP]  
> Chessbase does not need these files, if you open the PGN file again Chessbase will create the files again. You can only delete the files if you have closed Chessbase.

The flag deletes all pgi and ini files of Chessbase from the folder. This leaves the PGN files. Chessbase archives and CBH archives remain unaffected.
```bash
pgn -removecb
```